### PR TITLE
Fix incorrect formatting for Linking animation numbering.

### DIFF
--- a/Sources/Plasma/Apps/plClient/external/render_svg.py
+++ b/Sources/Plasma/Apps/plClient/external/render_svg.py
@@ -197,7 +197,7 @@ def render_loading_logo(inpath, outpath):
 			svg.render_cairo(ctx)
 			ctx.restore()
 
-			surface.write_to_png(os.path.join(outpath, "xLoading_Linking.{0:02}.png".format(frame)))
+			surface.write_to_png(os.path.join(outpath, "xLoading_Linking.{0:03}.png".format(frame)))
 
 def render_loading_text(inpath, outpath):
 	resSize = {"width":192, "height":41}


### PR DESCRIPTION
This fixes an incorrect amount of padding in the resource names for the Linking animation.  The animation has 180 frames, but we were only padding it to two digits (a holdover from the original 18-frame spinning book).  This error made simple sorting impossible.